### PR TITLE
Mccalluc/redundant runs

### DIFF
--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -5,7 +5,6 @@ from time import time
 from container_managers import docker_engine
 
 
-
 class DockerContainerSpec():
 
     def __init__(self, image_name, container_name,
@@ -46,11 +45,11 @@ class DockerClientWrapper():
             'bind': container_spec.container_input_path}]
         ports_spec = {'80/tcp': None}
         self._manager_run(container_spec.image_name,
-                      name=container_spec.container_name, # TODO: check
-                      detach=True,
-                      volumes=volume_spec,
-                      ports=ports_spec,
-                      labels=container_spec.labels)
+                          name=container_spec.container_name,
+                          detach=True,
+                          volumes=volume_spec,
+                          ports=ports_spec,
+                          labels=container_spec.labels)
         return self.lookup_container_url(container_spec.container_name)
 
     def _manager_run(self, image_name, cmd=None, volumes=(), **kwargs):

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -5,6 +5,20 @@ from time import time
 from container_managers import docker_engine
 
 
+
+class DockerContainerSpec():
+
+    def __init__(self, image_name, container_name,
+                 input={},
+                 container_input_path='/tmp/input.json',
+                 labels={}):
+        self.image_name = image_name
+        self.container_name = container_name
+        self.container_input_path = container_input_path
+        self.input = input
+        self.labels = labels
+
+
 class DockerClientWrapper():
 
     def __init__(self,
@@ -22,12 +36,16 @@ class DockerClientWrapper():
         return host_input_path
 
     def run(self, container_spec):
+        """
+        Run a given ContainerSpec. Returns the url for the container,
+        in contrast to the underlying method, which returns the logs.
+        """
         host_input_path = self._write_input_to_host(container_spec.input)
         volume_spec = [{
             'host': host_input_path,
             'bind': container_spec.container_input_path}]
         ports_spec = {'80/tcp': None}
-        self._sdk_run(container_spec.image_name,
+        self._manager_run(container_spec.image_name,
                       name=container_spec.container_name, # TODO: check
                       detach=True,
                       volumes=volume_spec,
@@ -35,16 +53,16 @@ class DockerClientWrapper():
                       labels=container_spec.labels)
         return self.lookup_container_url(container_spec.container_name)
 
-    def _sdk_run(self, image_name, cmd=None, volumes=(), **kwargs):
+    def _manager_run(self, image_name, cmd=None, volumes=(), **kwargs):
         """
-        Lower level wrapper for the SDK's run() method.
-        Significantly, "volumes" has a different structure here
+        Note that "volumes" has a different structure here
         than when using the SDK directly.
         """
         if (':' not in image_name):
             image_name += ':latest'
             # Without tag the SDK pulls every version; not what I expected.
             # https://github.com/docker/docker-py/issues/1510
+
         labels = kwargs.get('labels') or {}
         labels.update({self.root_label: 'true'})
         kwargs['labels'] = labels
@@ -53,7 +71,7 @@ class DockerClientWrapper():
         for volume in volumes:
             binding = volume.copy()
             if binding.get('mode'):
-                raise RuntimeError('"mode" should not be provided')
+                raise RuntimeError('"mode" should not be provided on {}'.format(volume))
             host_directory = binding.pop('host', None)
             if host_directory:
                 binding['mode'] = 'ro'  # For now, this is true.
@@ -62,6 +80,7 @@ class DockerClientWrapper():
                 host_directory = self._containers_manager.mkdtemp()
             volumes_dict[host_directory] = binding
         kwargs['volumes'] = volumes_dict
+        # Underlying method returns Docker logs
         return self._containers_manager.run(image_name, cmd, **kwargs)
 
     def lookup_container_url(self, container_name):
@@ -103,16 +122,3 @@ class DockerClientWrapper():
             # Doesn't work with non-integer values:
             # https://github.com/docker/docker-py/issues/1515
             return recent_log != ''
-
-
-class DockerContainerSpec():
-
-    def __init__(self, image_name, container_name,
-                 input={},
-                 container_input_path='/tmp/input.json',
-                 labels={}):
-        self.image_name = image_name
-        self.container_name = container_name
-        self.container_input_path = container_input_path
-        self.input = input
-        self.labels = labels

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -95,12 +95,13 @@ class DockerTests(unittest.TestCase):
             'host': self.tmp,
             'bind': '/usr/share/nginx/html'}]
         ports_spec = {'80/tcp': None}
-        self.client_wrapper._manager_run('nginx:1.10.3-alpine',
-                   name=container_name,
-                   detach=True,
-                   volumes=volume_spec,
-                   ports=ports_spec,
-                   labels={self.test_label: 'true'})
+        self.client_wrapper._manager_run(
+            'nginx:1.10.3-alpine',
+            name=container_name,
+            detach=True,
+            volumes=volume_spec,
+            ports=ports_spec,
+            labels={self.test_label: 'true'})
         return self.client_wrapper.lookup_container_url(container_name)
 
     def assert_url_content(self, url, content, client=django.test.Client()):

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -188,41 +188,39 @@ class DockerTests(unittest.TestCase):
     #     self.assertEqual(output, input + '\n')
     #     # Note that this doesn't really confirm that an outside volume was created,
     #     # but better than nothing.
-    #
-    # def test_purge(self):
-    #     """
-    #     WARNING: I think this is prone to race conditions.
-    #     If you get an error, try just giving it more time.
-    #     """
-    #     self.assertEqual(0, self.count_my_containers())
-    #
-    #     container_name = self.timestamp()
-    #     DockerContainerSpec(
-    #         manager=self.manager,
-    #         image_name='nginx:1.10.3-alpine',
-    #         container_name=container_name,
-    #         labels={self.test_label: 'true'}).run()
-    #     self.assertEqual(1, self.count_my_containers())
-    #
-    #     self.client_wrapper.purge_inactive(5)
-    #     self.assertEqual(1, self.count_my_containers())
-    #     # Even without activity, it should not be purged if younger than the limit.
-    #
-    #     sleep(2)
-    #
-    #     url = '/docker/{}/'.format(container_name)
-    #     self.assert_url_content(url, 'Welcome to nginx!')
-    #
-    #     # Be careful of race conditions if developing locally:
-    #     # I had to give a bit more time for the same test to pass with remote Docker.
-    #     self.client_wrapper.purge_inactive(4)
-    #     sleep(2)
-    #
-    #     self.assertEqual(1, self.count_my_containers())
-    #     # With a tighter time limit, recent activity should keep it alive.
-    #
-    #     sleep(2)
-    #
-    #     self.client_wrapper.purge_inactive(0)
-    #     self.assertEqual(0, self.count_my_containers())
-    #     # But with an even tighter limit, it should be purged.
+
+    def test_purge(self):
+        """
+        WARNING: I think this is prone to race conditions.
+        If you get an error, try just giving it more time.
+        """
+        self.assertEqual(0, self.count_my_containers())
+
+        url = self.client_wrapper.run(DockerContainerSpec(
+            image_name='nginx:1.10.3-alpine',
+            container_name=self.timestamp(),
+            labels={self.test_label: 'true'}
+        ))
+        self.assertEqual(1, self.count_my_containers())
+
+        self.client_wrapper.purge_inactive(5)
+        self.assertEqual(1, self.count_my_containers())
+        # Even without activity, it should not be purged if younger than the limit.
+
+        sleep(2)
+
+        self.assert_url_content(url, 'Welcome to nginx!')
+
+        # Be careful of race conditions if developing locally:
+        # I had to give a bit more time for the same test to pass with remote Docker.
+        self.client_wrapper.purge_inactive(4)
+        sleep(2)
+
+        self.assertEqual(1, self.count_my_containers())
+        # With a tighter time limit, recent activity should keep it alive.
+
+        sleep(2)
+
+        self.client_wrapper.purge_inactive(0)
+        self.assertEqual(0, self.count_my_containers())
+        # But with an even tighter limit, it should be purged.

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -141,53 +141,53 @@ class DockerTests(unittest.TestCase):
         ))
         self.assert_url_content(url, '{"foo": "bar"}')
 
-    # def test_docker_proxy(self):
-    #     container_name = self.timestamp()
-    #     hello_html = '<html><body>hello proxy</body></html>'
-    #     self.one_file_server(container_name, hello_html)
-    #     url = '/docker/{}/'.format(container_name)
-    #     self.assert_url_content(url, hello_html)
-    #
-    # def test_hello_world(self):
-    #     input = 'hello world'
-    #     output = self.client_wrapper.run(
-    #         'alpine:3.4',
-    #         'echo ' + input,
-    #         labels={self.test_label: 'true'}
-    #     )
-    #     self.assertEqual(output, input + '\n')
-    #
-    # def test_httpd(self):
-    #     container_name = self.timestamp()
-    #     hello_html = '<html><body>hello direct</body></html>'
-    #     url = self.one_file_server(container_name, hello_html)
-    #     self.assert_url_content(url, hello_html, client=requests)
-    #
-    # def test_mount_host_volumes(self):
-    #     input = 'hello world\n'
-    #     self.write_to_host(input, os.path.join(self.tmp, 'world.txt'))
-    #     volume_spec = [{'host': self.tmp, 'bind': '/hello'}]
-    #     output = self.client_wrapper.run(
-    #         'alpine:3.4',
-    #         'cat /hello/world.txt',
-    #         labels={self.test_label: 'true'},
-    #         volumes=volume_spec
-    #     )
-    #     self.assertEqual(output, input + '\n')
-    #
-    # def test_mount_scratch_volumes(self):
-    #     volume_spec = [{'bind': '/hello'}]
-    #     self.assertEqual(volume_spec[0].get('host'), None)  # Note: No explicit volume.
-    #     input = 'hello_world'  # TODO: Without underscore, only "hello" comes back?
-    #     output = self.client_wrapper.run(
-    #         'alpine:3.4',
-    #         'sh -c "echo \"{}\" > /hello/world.txt; cat /hello/world.txt"'.format(input),
-    #         labels={self.test_label: 'true'},
-    #         volumes=volume_spec
-    #     )
-    #     self.assertEqual(output, input + '\n')
-    #     # Note that this doesn't really confirm that an outside volume was created,
-    #     # but better than nothing.
+    def test_docker_proxy(self):
+        container_name = self.timestamp()
+        hello_html = '<html><body>hello proxy</body></html>'
+        self.one_file_server(container_name, hello_html)
+        url = '/docker/{}/'.format(container_name)
+        self.assert_url_content(url, hello_html)
+
+    def test_hello_world(self):
+        input = 'hello world'
+        output = self.client_wrapper._manager_run(
+            'alpine:3.4',
+            'echo ' + input,
+            labels={self.test_label: 'true'}
+        )
+        self.assertEqual(output, input + '\n')
+
+    def test_httpd(self):
+        container_name = self.timestamp()
+        hello_html = '<html><body>hello direct</body></html>'
+        url = self.one_file_server(container_name, hello_html)
+        self.assert_url_content(url, hello_html, client=requests)
+
+    def test_mount_host_volumes(self):
+        input = 'hello world\n'
+        self.write_to_host(input, os.path.join(self.tmp, 'world.txt'))
+        volume_spec = [{'host': self.tmp, 'bind': '/hello'}]
+        output = self.client_wrapper._manager_run(
+            'alpine:3.4',
+            'cat /hello/world.txt',
+            labels={self.test_label: 'true'},
+            volumes=volume_spec
+        )
+        self.assertEqual(output, input + '\n')
+
+    def test_mount_scratch_volumes(self):
+        volume_spec = [{'bind': '/hello'}]
+        self.assertEqual(volume_spec[0].get('host'), None)  # Note: No explicit volume.
+        input = 'hello_world'  # TODO: Without underscore, only "hello" comes back?
+        output = self.client_wrapper._manager_run(
+            'alpine:3.4',
+            'sh -c "echo \"{}\" > /hello/world.txt; cat /hello/world.txt"'.format(input),
+            labels={self.test_label: 'true'},
+            volumes=volume_spec
+        )
+        self.assertEqual(output, input + '\n')
+        # Note that this doesn't really confirm that an outside volume was created,
+        # but better than nothing.
 
     def test_purge(self):
         """

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -11,7 +11,6 @@ from distutils import dir_util
 from shutil import rmtree
 from time import sleep
 from django_docker_engine.docker_utils import DockerClientWrapper, DockerContainerSpec
-from django_docker_engine.container_managers import docker_engine
 
 
 class DockerTests(unittest.TestCase):
@@ -23,17 +22,16 @@ class DockerTests(unittest.TestCase):
             base,
             re.sub(r'\W', '_', str(datetime.datetime.now())))
         self.mkdir_on_host(self.tmp)
-        self.manager = docker_engine.DockerEngineManager()
-        self.client = DockerClientWrapper(manager=self.manager)
-        self.test_label = self.client.root_label + '.test'
-        self.initial_containers = self.client.list()
+        self.client_wrapper = DockerClientWrapper()
+        self.test_label = self.client_wrapper.root_label + '.test'
+        self.initial_containers = self.client_wrapper.list()
         # There may be containers running which are not "my containers".
         self.assertEqual(0, self.count_my_containers())
 
     def tearDown(self):
         self.rmdir_on_host(self.tmp)
-        self.client.purge_by_label(self.test_label)
-        final_containers = self.client.list()
+        self.client_wrapper.purge_by_label(self.test_label)
+        final_containers = self.client_wrapper.list()
         self.assertEqual(self.initial_containers, final_containers)
 
     # Utils for accessing remote docker engine:
@@ -87,7 +85,7 @@ class DockerTests(unittest.TestCase):
         return re.sub(r'\W', '_', str(datetime.datetime.now()))
 
     def count_my_containers(self):
-        return len(self.client.list(
+        return len(self.client_wrapper.list(
             filters={'label': self.test_label}
         ))
 
@@ -97,14 +95,13 @@ class DockerTests(unittest.TestCase):
             'host': self.tmp,
             'bind': '/usr/share/nginx/html'}]
         ports_spec = {'80/tcp': None}
-        client = self.client
-        client.run('nginx:1.10.3-alpine',
+        self.client_wrapper._manager_run('nginx:1.10.3-alpine',
                    name=container_name,
                    detach=True,
                    volumes=volume_spec,
                    ports=ports_spec,
                    labels={self.test_label: 'true'})
-        return client.lookup_container_url(container_name)
+        return self.client_wrapper.lookup_container_url(container_name)
 
     def assert_url_content(self, url, content, client=django.test.Client()):
         for i in xrange(10):
@@ -127,110 +124,105 @@ class DockerTests(unittest.TestCase):
         self.assertTrue(True)
 
     def test_container_spec_no_input(self):
-        container_name = self.timestamp()
-        DockerContainerSpec(
-            manager=self.manager,
+        url = self.client_wrapper.run(DockerContainerSpec(
             image_name='nginx:1.10.3-alpine',
-            container_name=container_name,
-            labels={self.test_label: 'true'}).run()
-        url = '/docker/{}/'.format(container_name)
+            container_name=self.timestamp(),
+            labels={self.test_label: 'true'}
+        ))
         self.assert_url_content(url, 'Welcome to nginx!')
 
     def test_container_spec_with_input(self):
-        container_name = self.timestamp()
-        DockerContainerSpec(
-            manager=self.manager,
+        url = self.client_wrapper.run(DockerContainerSpec(
             image_name='nginx:1.10.3-alpine',
-            container_name=container_name,
+            container_name=self.timestamp(),
+            labels={self.test_label: 'true'},
             input={'foo': 'bar'},
-            container_input_path='/usr/share/nginx/html/index.html',
-            labels={self.test_label: 'true'}
-        ).run()
-        url = '/docker/{}/'.format(container_name)
+            container_input_path='/usr/share/nginx/html/index.html'
+        ))
         self.assert_url_content(url, '{"foo": "bar"}')
 
-    def test_docker_proxy(self):
-        container_name = self.timestamp()
-        hello_html = '<html><body>hello proxy</body></html>'
-        self.one_file_server(container_name, hello_html)
-        url = '/docker/{}/'.format(container_name)
-        self.assert_url_content(url, hello_html)
-
-    def test_hello_world(self):
-        input = 'hello world'
-        output = self.client.run(
-            'alpine:3.4',
-            'echo ' + input,
-            labels={self.test_label: 'true'}
-        )
-        self.assertEqual(output, input + '\n')
-
-    def test_httpd(self):
-        container_name = self.timestamp()
-        hello_html = '<html><body>hello direct</body></html>'
-        url = self.one_file_server(container_name, hello_html)
-        self.assert_url_content(url, hello_html, client=requests)
-
-    def test_mount_host_volumes(self):
-        input = 'hello world\n'
-        self.write_to_host(input, os.path.join(self.tmp, 'world.txt'))
-        volume_spec = [{'host': self.tmp, 'bind': '/hello'}]
-        output = self.client.run(
-            'alpine:3.4',
-            'cat /hello/world.txt',
-            labels={self.test_label: 'true'},
-            volumes=volume_spec
-        )
-        self.assertEqual(output, input + '\n')
-
-    def test_mount_scratch_volumes(self):
-        volume_spec = [{'bind': '/hello'}]
-        self.assertEqual(volume_spec[0].get('host'), None)  # Note: No explicit volume.
-        input = 'hello_world'  # TODO: Without underscore, only "hello" comes back?
-        output = self.client.run(
-            'alpine:3.4',
-            'sh -c "echo \"{}\" > /hello/world.txt; cat /hello/world.txt"'.format(input),
-            labels={self.test_label: 'true'},
-            volumes=volume_spec
-        )
-        self.assertEqual(output, input + '\n')
-        # Note that this doesn't really confirm that an outside volume was created,
-        # but better than nothing.
-
-    def test_purge(self):
-        """
-        WARNING: I think this is prone to race conditions.
-        If you get an error, try just giving it more time.
-        """
-        self.assertEqual(0, self.count_my_containers())
-
-        container_name = self.timestamp()
-        DockerContainerSpec(
-            manager=self.manager,
-            image_name='nginx:1.10.3-alpine',
-            container_name=container_name,
-            labels={self.test_label: 'true'}).run()
-        self.assertEqual(1, self.count_my_containers())
-
-        self.client.purge_inactive(5)
-        self.assertEqual(1, self.count_my_containers())
-        # Even without activity, it should not be purged if younger than the limit.
-
-        sleep(2)
-
-        url = '/docker/{}/'.format(container_name)
-        self.assert_url_content(url, 'Welcome to nginx!')
-
-        # Be careful of race conditions if developing locally:
-        # I had to give a bit more time for the same test to pass with remote Docker.
-        self.client.purge_inactive(4)
-        sleep(2)
-
-        self.assertEqual(1, self.count_my_containers())
-        # With a tighter time limit, recent activity should keep it alive.
-
-        sleep(2)
-
-        self.client.purge_inactive(0)
-        self.assertEqual(0, self.count_my_containers())
-        # But with an even tighter limit, it should be purged.
+    # def test_docker_proxy(self):
+    #     container_name = self.timestamp()
+    #     hello_html = '<html><body>hello proxy</body></html>'
+    #     self.one_file_server(container_name, hello_html)
+    #     url = '/docker/{}/'.format(container_name)
+    #     self.assert_url_content(url, hello_html)
+    #
+    # def test_hello_world(self):
+    #     input = 'hello world'
+    #     output = self.client_wrapper.run(
+    #         'alpine:3.4',
+    #         'echo ' + input,
+    #         labels={self.test_label: 'true'}
+    #     )
+    #     self.assertEqual(output, input + '\n')
+    #
+    # def test_httpd(self):
+    #     container_name = self.timestamp()
+    #     hello_html = '<html><body>hello direct</body></html>'
+    #     url = self.one_file_server(container_name, hello_html)
+    #     self.assert_url_content(url, hello_html, client=requests)
+    #
+    # def test_mount_host_volumes(self):
+    #     input = 'hello world\n'
+    #     self.write_to_host(input, os.path.join(self.tmp, 'world.txt'))
+    #     volume_spec = [{'host': self.tmp, 'bind': '/hello'}]
+    #     output = self.client_wrapper.run(
+    #         'alpine:3.4',
+    #         'cat /hello/world.txt',
+    #         labels={self.test_label: 'true'},
+    #         volumes=volume_spec
+    #     )
+    #     self.assertEqual(output, input + '\n')
+    #
+    # def test_mount_scratch_volumes(self):
+    #     volume_spec = [{'bind': '/hello'}]
+    #     self.assertEqual(volume_spec[0].get('host'), None)  # Note: No explicit volume.
+    #     input = 'hello_world'  # TODO: Without underscore, only "hello" comes back?
+    #     output = self.client_wrapper.run(
+    #         'alpine:3.4',
+    #         'sh -c "echo \"{}\" > /hello/world.txt; cat /hello/world.txt"'.format(input),
+    #         labels={self.test_label: 'true'},
+    #         volumes=volume_spec
+    #     )
+    #     self.assertEqual(output, input + '\n')
+    #     # Note that this doesn't really confirm that an outside volume was created,
+    #     # but better than nothing.
+    #
+    # def test_purge(self):
+    #     """
+    #     WARNING: I think this is prone to race conditions.
+    #     If you get an error, try just giving it more time.
+    #     """
+    #     self.assertEqual(0, self.count_my_containers())
+    #
+    #     container_name = self.timestamp()
+    #     DockerContainerSpec(
+    #         manager=self.manager,
+    #         image_name='nginx:1.10.3-alpine',
+    #         container_name=container_name,
+    #         labels={self.test_label: 'true'}).run()
+    #     self.assertEqual(1, self.count_my_containers())
+    #
+    #     self.client_wrapper.purge_inactive(5)
+    #     self.assertEqual(1, self.count_my_containers())
+    #     # Even without activity, it should not be purged if younger than the limit.
+    #
+    #     sleep(2)
+    #
+    #     url = '/docker/{}/'.format(container_name)
+    #     self.assert_url_content(url, 'Welcome to nginx!')
+    #
+    #     # Be careful of race conditions if developing locally:
+    #     # I had to give a bit more time for the same test to pass with remote Docker.
+    #     self.client_wrapper.purge_inactive(4)
+    #     sleep(2)
+    #
+    #     self.assertEqual(1, self.count_my_containers())
+    #     # With a tighter time limit, recent activity should keep it alive.
+    #
+    #     sleep(2)
+    #
+    #     self.client_wrapper.purge_inactive(0)
+    #     self.assertEqual(0, self.count_my_containers())
+    #     # But with an even tighter limit, it should be purged.


### PR DESCRIPTION
Address the confusion about having two "run" methods in dock_utils.py. I'm going to make another branch off of this to see if it makes sense to get rid of the free-floating `_manager_run`. Note that there is still a run method in Manager classes, but that seems different enough to be ok?