### PR TITLE
Mccalluc/error page

### DIFF
--- a/README-AWS.rst
+++ b/README-AWS.rst
@@ -1,0 +1,39 @@
+==========
+AWS Extras
+==========
+
+Before each test run, the environment variable DOCKER_HOST is checked:
+If unset, the local Docker engine will be used, but it could also refer
+to an AWS instance.
+
+You'll need a django_docker_cloudformation.pem and sufficient AWS privs.
+
+The tests shouldn't leak AWS resources, but if they do:
+
+- `CloudFormation Stacks <https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filter=active>`_
+- `Security Groups <https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SecurityGroups:search=django_docker_;sort=groupId>`_
+- `EC2 Instances <https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:search=django_docker_;sort=keyName>`_
+
+Clean up of stacks is easy on the command line::
+
+    aws cloudformation list-stacks \
+        --query 'StackSummaries[].[StackName,StackStatus]' \
+        --output text | \
+    grep -v DELETE_COMPLETE | \
+    grep django-docker | \
+    cut -f 1 | \
+    xargs -n 1 aws cloudformation delete-stack --stack-name
+
+If lower level resources have leaked, they can be handled independently::
+
+    aws ec2 describe-instances \
+        --filters Name=tag:project,Values=django_docker_engine \
+        --query 'Reservations[].Instances[].[InstanceId]' \
+        --output text | \
+    xargs aws ec2 terminate-instances --instance-ids
+
+    aws ec2 describe-security-groups \
+        --filters Name=description,Values='Security group for django_docker_engine' \
+        --query 'SecurityGroups[].[GroupId]' \
+        --output text | \
+    xargs -n 1 aws ec2 delete-security-group --group-id

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ either implicitly as an envvar, or explicitly via an instance of the SDK client.
 If this will be done automatically, you can ensure that the user has the appropriate privs by running
 ``set_user_policy.py``.
 
+`Notes on working with AWS <README-AWS.rst>` are available.
+
 .....
 AWS-ECS
 .....
@@ -119,8 +121,6 @@ For more detail, consult the `generated documentation <docs.md>`_.
 Development
 -----------
 
-You'll need a django_docker_cloudformation.pem and sufficient AWS privs.
-
 ::
 
     git clone https://github.com/mccalluc/django_docker_engine.git
@@ -128,36 +128,6 @@ You'll need a django_docker_cloudformation.pem and sufficient AWS privs.
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
     python manage.py test --verbosity=2
-
-The tests shouldn't leak AWS resources, but if they do:
-
-- `CloudFormation Stacks <https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filter=active>`_
-- `Security Groups <https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SecurityGroups:search=django_docker_;sort=groupId>`_
-- `EC2 Instances <https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:search=django_docker_;sort=keyName>`_
-
-Clean up of stacks is easy on the command line::
-
-    aws cloudformation list-stacks \
-        --query 'StackSummaries[].[StackName,StackStatus]' \
-        --output text | \
-    grep -v DELETE_COMPLETE | \
-    grep django-docker | \
-    cut -f 1 | \
-    xargs -n 1 aws cloudformation delete-stack --stack-name
-
-If lower level resources have leaked, they can be handled independently::
-
-    aws ec2 describe-instances \
-        --filters Name=tag:project,Values=django_docker_engine \
-        --query 'Reservations[].Instances[].[InstanceId]' \
-        --output text | \
-    xargs aws ec2 terminate-instances --instance-ids
-
-    aws ec2 describe-security-groups \
-        --filters Name=description,Values='Security group for django_docker_engine' \
-        --query 'SecurityGroups[].[GroupId]' \
-        --output text | \
-    xargs -n 1 aws ec2 delete-security-group --group-id
 
 
 ----------------

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -120,9 +120,7 @@ class DockerClientWrapper():
         """
         Removes containers which do not have recent log entries.
         """
-        logger.warn('purge_inactive')
         for container in self.list():
-            logger.warn('container: %s', container)
             # TODO: Confirm that it belongs to me
             if not self._is_active(container, seconds):
                 container.remove(force=True)
@@ -134,12 +132,10 @@ class DockerClientWrapper():
         utc_now = datetime.utcnow()
         seconds_since_start = (utc_now - utc_start).total_seconds()
         if seconds_since_start < seconds:
-            logger.warn('seconds_since_start < seconds')
             return True
         else:
             recent_log = container.logs(since=int(time() - seconds))
             # Logs are empty locally, but must contain something on travis?
-            logger.warn('logs: [%s]', recent_log)
             # Doesn't work with non-integer values:
             # https://github.com/docker/docker-py/issues/1515
             return recent_log != ''

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -1,8 +1,13 @@
 import json
+import logging
 import os
 from datetime import datetime
 from time import time
 from container_managers import docker_engine
+
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 class DockerContainerSpec():
@@ -115,7 +120,9 @@ class DockerClientWrapper():
         """
         Removes containers which do not have recent log entries.
         """
+        logger.warn('purge_inactive')
         for container in self.list():
+            logger.warn('container: %s', container)
             # TODO: Confirm that it belongs to me
             if not self._is_active(container, seconds):
                 container.remove(force=True)
@@ -127,9 +134,12 @@ class DockerClientWrapper():
         utc_now = datetime.utcnow()
         seconds_since_start = (utc_now - utc_start).total_seconds()
         if seconds_since_start < seconds:
+            logger.warn('seconds_since_start < seconds')
             return True
         else:
             recent_log = container.logs(since=int(time() - seconds))
+            # Logs are empty locally, but must contain something on travis?
+            logger.warn('logs: [%s]', recent_log)
             # Doesn't work with non-integer values:
             # https://github.com/docker/docker-py/issues/1515
             return recent_log != ''

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -73,6 +73,9 @@ class Proxy():
             def get(self, request, *args, **kwargs):
                 response = HttpResponse(content)
                 response.status_code = 503
+                response.reason_phrase = 'Container not yet available'
+                # Non-standard, but more clear than default;
+                # Also, before 1.9, this is not set just by changing status code.
                 return response
             http_method_named = ['get']
         return PleaseWaitView

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import logging
-import django
 from django.conf.urls import url
 from django.http import HttpResponse
 from docker.errors import NotFound
@@ -10,6 +9,10 @@ from docker_utils import DockerClientWrapper
 from datetime import datetime
 from collections import namedtuple
 
+try:
+    from django.views import View
+except ImportError:  # Support older versions of django
+    from django.views.generic import View
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -66,7 +69,7 @@ class Proxy():
 
     def _view_factory(self, content):
         # TODO: Is there a less weird way to do this?
-        class PleaseWaitView(django.views.View):
+        class PleaseWaitView(View):
             def get(self, request, *args, **kwargs):
                 response = HttpResponse(content)
                 response.status_code = 503

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 
 import logging
+import django
 from django.conf.urls import url
 from django.http import HttpResponse
-from django.views import View
 from docker.errors import NotFound
 from httpproxy.views import HttpProxy
 from docker_utils import DockerClientWrapper
@@ -66,7 +66,7 @@ class Proxy():
 
     def _view_factory(self, content):
         # TODO: Is there a less weird way to do this?
-        class PleaseWaitView(View):
+        class PleaseWaitView(django.views.View):
             def get(self, request, *args, **kwargs):
                 response = HttpResponse(content)
                 response.status_code = 503

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -1,10 +1,15 @@
 from __future__ import print_function
 
+import logging
 from django.conf.urls import url
 from httpproxy.views import HttpProxy
 from docker_utils import DockerClientWrapper
 from datetime import datetime
 from collections import namedtuple
+
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 UrlPatterns = namedtuple('UrlPatterns', ['urlpatterns'])
 
@@ -47,6 +52,10 @@ class Proxy():
 
     def _proxy_view(self, request, container_name, url):
         self.logger.log(container_name, url)
-        container_url = DockerClientWrapper().lookup_container_url(container_name)
+        try:
+            logger.warn('lookup_container_url: %s', container_name)
+            container_url = DockerClientWrapper().lookup_container_url(container_name)
+        except:
+            logger.warn('Failed to find container url')
         view = HttpProxy.as_view(base_url=container_url)
         return view(request, url=url)

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -79,4 +79,3 @@ class Proxy():
                 return response
             http_method_named = ['get']
         return PleaseWaitView
-

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -53,9 +53,8 @@ class Proxy():
     def _proxy_view(self, request, container_name, url):
         self.logger.log(container_name, url)
         try:
-            logger.warn('lookup_container_url: %s', container_name)
             container_url = DockerClientWrapper().lookup_container_url(container_name)
         except:
-            logger.warn('Failed to find container url')
+            logger.warn('TODO: Failed to find container url')
         view = HttpProxy.as_view(base_url=container_url)
         return view(request, url=url)

--- a/django_docker_engine/proxy.py
+++ b/django_docker_engine/proxy.py
@@ -68,7 +68,9 @@ class Proxy():
         # TODO: Is there a less weird way to do this?
         class PleaseWaitView(View):
             def get(self, request, *args, **kwargs):
-                return HttpResponse(content)
+                response = HttpResponse(content)
+                response.status_code = 503
+                return response
             http_method_named = ['get']
         return PleaseWaitView
 

--- a/docs.md
+++ b/docs.md
@@ -3,12 +3,13 @@
 ### list(self, filters={})
 ### lookup_container_url(self, container_name)
 Given the name of a container, returns the url mapped to port 80.
+### pull(self, image_name, version='latest')
 ### purge_by_label(self, label)
 Removes all containers matching the label.
 ### purge_inactive(self, seconds)
 Removes containers which do not have recent log entries.
-### run(self, image_name, cmd=None, **kwargs)
-Wraps the SDK's run() method.
+### run(self, container_spec)
+Run a given ContainerSpec. Returns the url for the container,
+in contrast to the underlying method, which returns the logs.
 ## class DockerContainerSpec
-### __init__(self, image_name, container_name, manager, input={}, container_input_path='/tmp/input.json', labels={})
-### run(self)
+### __init__(self, image_name, container_name, input={}, container_input_path='/tmp/input.json', extra_directories=[], labels={})

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -3,6 +3,7 @@ import os
 import datetime
 import re
 import django
+import logging
 import mock
 import paramiko
 from urllib2 import URLError
@@ -12,6 +13,9 @@ from shutil import rmtree
 from time import sleep
 from django_docker_engine.docker_utils import DockerClientWrapper, DockerContainerSpec
 
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 class LiveDockerTests(unittest.TestCase):
 
@@ -176,6 +180,10 @@ class LiveDockerTests(unittest.TestCase):
         ))
         self.assertEqual(1, self.count_my_containers())
 
+        # TODO: This consistently fails for me locally,
+        # but seems to pass on travis?
+        # Logs are empty locally, but must contain something on travis?
+        logger.warn('logs: [%s]', self.client_wrapper.list()[0].logs())
         self.client_wrapper.purge_inactive(5)
         self.assertEqual(1, self.count_my_containers())
         # Even without activity, it should not be purged if younger than the limit.

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -94,7 +94,7 @@ class LiveDockerTests(unittest.TestCase):
             filters={'label': self.test_label}
         ))
 
-    def assert_url_content(self, url, content, client=django.test.Client()):
+    def assert_url_content_eventually(self, url, content, client=django.test.Client()):
         for i in xrange(10):
             try:
                 response = client.get(url)
@@ -120,7 +120,7 @@ class LiveDockerTests(unittest.TestCase):
             container_name=self.timestamp(),
             labels={self.test_label: 'true'}
         ))
-        self.assert_url_content(url, 'Welcome to nginx!')
+        self.assert_url_content_eventually(url, 'Welcome to nginx!')
 
     def test_container_spec_with_input(self):
         url = self.client_wrapper.run(DockerContainerSpec(
@@ -130,7 +130,7 @@ class LiveDockerTests(unittest.TestCase):
             input={'foo': 'bar'},
             container_input_path='/usr/share/nginx/html/index.html'
         ))
-        self.assert_url_content(url, '{"foo": "bar"}')
+        self.assert_url_content_eventually(url, '{"foo": "bar"}')
 
     def test_container_spec_with_extra_directories_bad(self):
         container_name = self.timestamp()
@@ -179,6 +179,7 @@ class LiveDockerTests(unittest.TestCase):
             labels={self.test_label: 'true'}
         ))
         self.assertEqual(1, self.count_my_containers())
+        self.assert_url_content_eventually(url, 'Welcome to nginx!')
 
         # TODO: This consistently fails for me locally,
         # but seems to pass on travis?
@@ -190,7 +191,7 @@ class LiveDockerTests(unittest.TestCase):
 
         sleep(2)
 
-        self.assert_url_content(url, 'Welcome to nginx!')
+        self.assert_url_content_eventually(url, 'Welcome to nginx!')
 
         # Be careful of race conditions if developing locally:
         # I had to give a bit more time for the same test to pass with remote Docker.

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -39,7 +39,7 @@ class LiveDockerTests(unittest.TestCase):
         self.test_label = self.client_wrapper.root_label + '.test'
         self.initial_containers = self.client_wrapper.list()
         # There may be containers running which are not "my containers".
-        self.assertEqual(0, self.count_my_containers())
+        self.assertEqual(0, self.count_containers())
 
     def tearDown(self):
         self.rmdir_on_host(self.tmp)
@@ -97,7 +97,7 @@ class LiveDockerTests(unittest.TestCase):
     def timestamp(self):
         return re.sub(r'\W', '_', str(datetime.datetime.now()))
 
-    def count_my_containers(self):
+    def count_containers(self):
         return len(self.client_wrapper.list(
             filters={'label': self.test_label}
         ))
@@ -179,18 +179,18 @@ class LiveDockerTests(unittest.TestCase):
         WARNING: I think this is prone to race conditions.
         If you get an error, try just giving it more time.
         """
-        self.assertEqual(0, self.count_my_containers())
+        self.assertEqual(0, self.count_containers())
 
         url = self.client_wrapper.run(DockerContainerSpec(
             image_name='nginx:1.10.3-alpine',
             container_name=self.timestamp(),
             labels={self.test_label: 'true'}
         ))
-        self.assertEqual(1, self.count_my_containers())
+        self.assertEqual(1, self.count_containers())
         self.assert_url_loads_eventually(url, 'Welcome to nginx!')
 
         self.client_wrapper.purge_inactive(5)
-        self.assertEqual(1, self.count_my_containers())
+        self.assertEqual(1, self.count_containers())
         # Even without activity, it should not be purged if younger than the limit.
 
         sleep(2)
@@ -202,13 +202,13 @@ class LiveDockerTests(unittest.TestCase):
         self.client_wrapper.purge_inactive(4)
         sleep(2)
 
-        self.assertEqual(1, self.count_my_containers())
+        self.assertEqual(1, self.count_containers())
         # With a tighter time limit, recent activity should keep it alive.
 
         sleep(2)
 
         self.client_wrapper.purge_inactive(0)
-        self.assertEqual(0, self.count_my_containers())
+        self.assertEqual(0, self.count_containers())
         # But with an even tighter limit, it should be purged.
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -5,7 +5,7 @@ from django.test import RequestFactory
 
 class ProxyTests(unittest.TestCase):
 
-    def test_proxy(self):
+    def test_proxy_please_wait(self):
         content = 'please-wait-test-message'
         proxy = Proxy(
             logger=NullLogger(),
@@ -20,5 +20,6 @@ class ProxyTests(unittest.TestCase):
             url='fake-url'
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.reason_phrase, 'Service Unavailable')
         self.assertEqual(response.content, content)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,5 +1,4 @@
 import unittest
-import django
 from django_docker_engine.proxy import NullLogger, Proxy
 from django.test import RequestFactory
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,9 @@
+import unittest
+from django_docker_engine.proxy import NullLogger, Proxy
+
+
+class ProxyTests(unittest.TestCase):
+
+    def test_proxy(self):
+        urlpatterns = Proxy(NullLogger()).url_patterns()
+        self.assertEquals(len(urlpatterns), 1)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,7 +6,11 @@ from django.test import RequestFactory
 class ProxyTests(unittest.TestCase):
 
     def test_proxy(self):
-        proxy = Proxy(NullLogger())
+        content = 'please-wait-test-message'
+        proxy = Proxy(
+            logger=NullLogger(),
+            please_wait_content=content
+        )
         urlpatterns = proxy.url_patterns()
         self.assertEquals(len(urlpatterns), 1)
 
@@ -17,4 +21,4 @@ class ProxyTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, 'Please wait.')
+        self.assertEqual(response.content, content)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,5 @@
 import unittest
+import django
 from django_docker_engine.proxy import NullLogger, Proxy
 from django.test import RequestFactory
 
@@ -21,5 +22,5 @@ class ProxyTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 503)
-        self.assertEqual(response.reason_phrase, 'Service Unavailable')
+        self.assertEqual(response.reason_phrase, 'Container not yet available')
         self.assertEqual(response.content, content)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,9 +1,20 @@
 import unittest
 from django_docker_engine.proxy import NullLogger, Proxy
+from django.test import RequestFactory
 
 
 class ProxyTests(unittest.TestCase):
 
     def test_proxy(self):
-        urlpatterns = Proxy(NullLogger()).url_patterns()
+        proxy = Proxy(NullLogger())
+        urlpatterns = proxy.url_patterns()
         self.assertEquals(len(urlpatterns), 1)
+
+        response = urlpatterns[0].callback(
+            request=RequestFactory().get('/fake-url'),
+            container_name='fake-container',
+            url='fake-url'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'Please wait.')


### PR DESCRIPTION
@scottx611x : Main idea is that static html can can be given until the docker container is up. Tests pass locally, but hit this on Travis:
```
File "/home/travis/build/refinery-platform/django_docker_engine/django_docker_engine/proxy.py", line 6, in <module>
    from django.views import View
ImportError: cannot import name View
```

Will try fiddling with my environment to see if I can reproduce. 

--> It's a difference between python 1.7.1 and 1.10.6