### PR TITLE
Add link to docs [skip-ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ More information:
 - [for users of the library](https://github.com/refinery-platform/django_docker_engine/blob/master/README-USERS.md)
 - [for developers of the library](https://github.com/refinery-platform/django_docker_engine/blob/master/README-DEVS.md)
 - [background motivations and future directions](https://github.com/refinery-platform/django_docker_engine/blob/master/README-PROVENANCE.md)
+- [API documentation](https://www.pydoc.io/pypi/django-docker-engine-0.0.48/)


### PR DESCRIPTION
- There doesn't seem to be an option to just reference the latest version of the docs.
- Am I doing something dumb that `skip-ci` doesn't seem to be obeyed? --> Yes I am: no dash in `skip ci`.