### PR TITLE
Note that python (and pip) needs to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ In order for a Docker container to work with this package it must:
 ## Quick Demo
 
 Install [Docker](https://store.docker.com/search?offering=community&type=edition)
-if you haven't already, then download the project, install dependencies, and
+and `python` and `pip`
+if you haven't already.
+
+Then download the project, install dependencies, and
 run the demo server:
 
 ```


### PR DESCRIPTION
Fresh cloud installs on (for example) Ubuntu 18.04 don't come with python or pip.
I've suggested that they be installed.