### PR TITLE
Checkpoint: We do not always need a data_dir

### DIFF
--- a/README-USERS.md
+++ b/README-USERS.md
@@ -77,24 +77,33 @@ TODO: AWS provides its own wrapper around Docker through ECS. We will need to ab
 Docker SDK provides so that we can use either interface, as needed.
 
 
-## Launching Containers
+## Walk through
 
-`DockerContainerSpec` exposes a subset of Docker functionality so your application can launch containers as needed:
+`django_docker_engine.docker_utils` exposes a subset of Docker functionality 
+so your application can launch containers as needed:
 
 ```
-$ echo 'Hello World' > /tmp/hello.txt
 $ python
->>> from django_docker_engine.docker_utils import (DockerClientWrapper, DockerContainerSpec)
->>> DockerClientWrapper('/tmp/docker', do_input_json_file=True).run(
-      DockerContainerSpec(
-        image_name='nginx:1.10.3-alpine',
-        container_name='my-server',
-        container_input_path='/tmp/hello.txt'
+>>> from django_docker_engine.docker_utils import (DockerClientWrapper, DockerContainerSpec, DockerClientSpec)
+>>> client_spec = DockerClientSpec(
+        do_input_json_envvar=True
       )
-    )
-$ python manage.py runserver
-$ curl http://localhost:8000/docker/my-server/hello.txt
-Hello World
+>>> container_spec = DockerContainerSpec(
+        image_name='nginx:1.10.3-alpine',
+        container_name='my-server'
+      )
+>>> DockerClientWrapper(client_spec).run(container_spec)
 ```
+Note the URL that's returned: You'll get the Nginx welcome page if you visit it.
+You can run `docker ps` to see the container you've started.
+
+Now let's see how proxying works:
+```
+$ python manage.py runserver &
+$ curl http://localhost:8000/docker/my-server | grep title
+<title>Welcome to nginx!</title>
+```
+Django receives the request, looks up the container from the name in the URL path,
+proxies the request, and returns the same Nginx welcome page.
 
 For more detail, consult the [generated documentation](docs.md).

--- a/demo_host_routing/proxy_url_patterns.py
+++ b/demo_host_routing/proxy_url_patterns.py
@@ -1,5 +1,7 @@
 from django_docker_engine.docker_utils import DockerClientSpec
 from django_docker_engine.proxy import Proxy
 
-spec = DockerClientSpec('/tmp/django-docker-data', do_input_json_envvar=True)
+spec = DockerClientSpec(
+    data_dir='/tmp/django-docker-data',
+    do_input_json_envvar=True)
 urlpatterns = Proxy(spec).url_patterns()

--- a/demo_path_routing/proxy_url_patterns.py
+++ b/demo_path_routing/proxy_url_patterns.py
@@ -1,5 +1,7 @@
 from django_docker_engine.docker_utils import DockerClientSpec
 from django_docker_engine.proxy import Proxy
 
-spec = DockerClientSpec('/tmp/django-docker-data', do_input_json_envvar=True)
+spec = DockerClientSpec(
+    data_dir='/tmp/django-docker-data',
+    do_input_json_envvar=True)
 urlpatterns = Proxy(spec).url_patterns()

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -32,7 +32,8 @@ class DockerContainerSpec():
 
 class DockerClientSpec():
 
-    def __init__(self, data_dir,
+    def __init__(self,
+                 data_dir=None,
                  do_input_json_file=False,
                  do_input_json_envvar=False,
                  input_json_url=None):
@@ -49,6 +50,10 @@ class DockerClientSpec():
         #   Creates potentially problematic huge envvar
         # - input_json_url:
         #   World-readable URL could be an unwanted leak
+        if do_input_json_file:
+            assert data_dir,\
+            'If the container reads input from a file mounted on the host, '
+            'a data_dir needs be given.'
         self.data_dir = data_dir
         self.do_input_json_file = do_input_json_file
         self.do_input_json_envvar = do_input_json_envvar

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -28,8 +28,9 @@ class LiveDockerTests(unittest.TestCase):
 
     @property
     def spec(self):
-        return DockerClientSpec('/tmp/django-docker-engine-test',
-                                do_input_json_envvar=True)
+        return DockerClientSpec(
+            data_dir='/tmp/django-docker-engine-test',
+            do_input_json_envvar=True)
 
     def setUp(self):
         # Docker Engine's clock stops when the computer goes to sleep,
@@ -243,8 +244,9 @@ class LiveDockerTestsCleanJsonFile(LiveDockerTestsClean):
 
     @property
     def spec(self):
-        return DockerClientSpec('/tmp/django-docker-engine-test',
-                                do_input_json_file=True)
+        return DockerClientSpec(
+            data_dir='/tmp/django-docker-engine-test',
+            do_input_json_file=True)
 
     def assert_correct_ls_tmp(self, ls_tmp_orig):
         self.assertGreater(self.ls_tmp(), ls_tmp_orig)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -27,7 +27,7 @@ class CSRFTests(unittest.TestCase):
     def _check_proxy_csrf(self, csrf_exempt=True):
         with mock.patch("django_docker_engine.proxy.csrf_exempt_decorator") \
                 as csrf_exempt_mock:
-            spec = DockerClientSpec('/tmp/django-docker-data',
+            spec = DockerClientSpec(data_dir='/tmp/django-docker-data',
                                     do_input_json_envvar=True)
             Proxy(spec, csrf_exempt=csrf_exempt).url_patterns()
             assert csrf_exempt_mock.called == csrf_exempt
@@ -48,7 +48,7 @@ class ProxyTests(unittest.TestCase):
         historian = FileHistorian(history_path)
         title_text = 'test-title'
         body_html = '<p>test-body</p>'
-        spec = DockerClientSpec('/tmp/django-docker-data',
+        spec = DockerClientSpec(data_dir='/tmp/django-docker-data',
                                 do_input_json_envvar=True)
         proxy = Proxy(
             docker_client_spec=spec,

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -36,7 +36,7 @@ class PathRoutingTests(unittest.TestCase):
         # TODO: Might use mkdtemp, but Docker couldn't see the directory?
         # self.tmp_dir = mkdtemp()
         # chmod(self.tmp_dir, 0777)
-        spec = DockerClientSpec(self.tmp_dir,
+        spec = DockerClientSpec(data_dir=self.tmp_dir,
                                 do_input_json_envvar=True)
         self.client = DockerClientWrapper(spec)
 
@@ -98,7 +98,7 @@ class HostRoutingTests(PathRoutingTests):
             '--settings', 'demo_host_routing.settings'
         ])
         time.sleep(1)
-        spec = DockerClientSpec(self.tmp_dir,
+        spec = DockerClientSpec(data_dir=self.tmp_dir,
                                 do_input_json_envvar=True)
         self.client = DockerClientWrapper(spec)
 


### PR DESCRIPTION
This is still a good idea... or maybe get rid of data_dir entirely, and insist that input be supplied via envvars? The particular PR will probably not be merged, but it serves as a reminder.