### PR TITLE
Mccalluc/better memory management

### DIFF
--- a/demo_path_routing_auth/forms.py
+++ b/demo_path_routing_auth/forms.py
@@ -15,8 +15,8 @@ class LaunchForm(forms.Form):
     tool = forms.ChoiceField(
         widget=forms.Select,
         choices=tuple(
-            (k, '{}: {}'.format(k, v['description']))
-            for k, v in tools.items())
+            (name, '{}: {}'.format(name, tool.description))
+            for name, tool in tools.items())
     )
     urls = UnvalidatedMultipleChoiceField()
     parameters_json = forms.CharField()

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -11,16 +11,16 @@ class Tool():
       (Doesn't need to be every possible valid input from that file.)
     input_f: Lambda which returns a dict which becomes the INPUT_JSON.
     container_port: If the tool uses a port other than 80.
-    memory_use: Expected memory use in MB.
+    mem_reservation_mb: Expected memory use in MB.
     '''
     # In 3.7, default values are supported for namedtuples. Until then:
 
-    def __init__(self, image, description, memory_use,
+    def __init__(self, image, description, mem_reservation_mb,
                  default_parameters=None, default_files=None,
                  container_port=None, input_f=None):
         self.image = image
         self.description = description
-        self.memory_use = memory_use
+        self.mem_reservation_mb = mem_reservation_mb
         self.default_parameters = [] \
             if default_parameters is None else default_parameters
         self.default_files = ['3x3.csv'] \
@@ -37,25 +37,25 @@ tools = {
     'debugger': Tool(
         'scottx611x/refinery-developer-vis-tool:v0.0.7',
         'Echo the user input',
-        memory_use=15
+        mem_reservation_mb=15
     ),
     'lineup': Tool(
         'mccalluc/lineup_refinery:v0.0.8',
         'Aggregate and sort heterogeneous data',
-        memory_use=11
+        mem_reservation_mb=11
     ),
     'intervene': Tool(
         'mccalluc/intervene:v0.0.5',
         'Set intersection Shiny app',
         default_files=['mESC.genes', 'Myotube.genes',
                        'pro-B.genes', 'Th-cell.genes'],
-        memory_use=208
+        mem_reservation_mb=208
     ),
     'shiny-demo': Tool(
         'mccalluc/shiny-heatmap-refinery:v0.0.2',
         'Trivial Shiny app',
         container_port=3838,
-        memory_use=120
+        mem_reservation_mb=120
     ),
     'igv-js': Tool(
         'gehlenborglab/docker_igv_js:v0.0.9',
@@ -77,7 +77,7 @@ tools = {
                 for (i, url) in enumerate(urls)
             },
         },
-        memory_use=15
+        mem_reservation_mb=15
     ),
     'higlass': Tool(
         'scottx611x/refinery-higlass-docker:v0.3.2',
@@ -90,7 +90,7 @@ tools = {
             },
             'extra_directories': ['/refinery-data/']
         },
-        memory_use=100  # Highly variable
+        mem_reservation_mb=100  # Highly variable
     ),
     'rna-seq': Tool(
         'mccalluc/heatmap_scatter_dash:v0.1.15',
@@ -100,7 +100,7 @@ tools = {
             'api_prefix': prefix,
             'extra_directories': ['/refinery-data/']
         },
-        memory_use=74
+        mem_reservation_mb=74
     ),
     'multiqc': Tool(
         'mccalluc/qualimap_multiqc_refinery:v0.0.7',
@@ -110,6 +110,6 @@ tools = {
             'file_relationships': urls,
             'extra_directories': ['/data/']
         },
-        memory_use=20
+        mem_reservation_mb=20
     )
 }

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -9,7 +9,7 @@ class Tool():
       (In Refinery, there is a UI.)
     default_files: Should match values in demo-data.csv.
       (Doesn't need to be every possible valid input from that file.)
-    input: Lambda which returns a dict which becomes the INPUT_JSON.
+    input_f: Lambda which returns a dict which becomes the INPUT_JSON.
     container_port: If the tool uses a port other than 80.
     memory_use: Expected memory use in MB.
     '''
@@ -17,7 +17,7 @@ class Tool():
 
     def __init__(self, image, description, memory_use,
                  default_parameters=None, default_files=None,
-                 container_port=None, extra_directories=None, input_f=None):
+                 container_port=None, input_f=None):
         self.image = image
         self.description = description
         self.memory_use = memory_use
@@ -27,8 +27,6 @@ class Tool():
             if default_files is None else default_files
         self.container_port = 80 \
             if container_port is None else container_port
-        self.extra_directories = [] \
-            if extra_directories is None else extra_directories
         self.input_f = (lambda urls, prefix: {
             'file_relationships': urls,
             'extra_directories': []
@@ -68,6 +66,7 @@ tools = {
         ],
         default_files=['NC_009084.gff'],
         input_f=lambda urls, prefix: {
+            'extra_directories': [],
             'node_info': {
                 'fake-uuid-{}'.format(i): {
                     'file_url': url,

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -94,14 +94,14 @@ tools = {
         memory_use=100  # Highly variable
     ),
     'rna-seq': Tool(
-        'mccalluc/heatmap_scatter_dash:v0.1.8',
+        'mccalluc/heatmap_scatter_dash:v0.1.15',
         'Linked visualization for gene expression',
         input_f=lambda urls, prefix: {
             'file_relationships': urls,
             'api_prefix': prefix,
             'extra_directories': ['/refinery-data/']
         },
-        memory_use=20  # TODO: Confirm
+        memory_use=74
     ),
     'multiqc': Tool(
         'mccalluc/qualimap_multiqc_refinery:v0.0.7',

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -1,58 +1,68 @@
+class Tool():
+    '''
+    Tool definition, analogous to those in
+    https://github.com/refinery-platform/visualization-tools
+
+    image: Dockerhub image with version tag
+    description: Displayed in UI
+    default_parameters: In demo, user can edit JSON.
+      (In Refinery, there is a UI.)
+    default_files: Should match values in demo-data.csv.
+      (Doesn't need to be every possible valid input from that file.)
+    input: Lambda which returns a dict which becomes the INPUT_JSON.
+    container_port: If the tool uses a port other than 80.
+    memory_use: Expected memory use in MB.
+    '''
+    # In 3.7, default values are supported for namedtuples. Until then:
+    def __init__(self, image, description, memory_use,
+                 default_parameters=None,
+                 default_files=None, input_f=None, container_port=None):
+        self.image = image
+        self.description = description
+        self.memory_use = memory_use
+        self.default_parameters = [] \
+            if default_parameters is None else default_parameters
+        self.default_files = ['3x3.csv'] \
+            if default_files is None  else default_files
+        self.container_port = 80 \
+            if container_port is None else container_port
+        self.input_f = lambda urls, prefix: {
+            'file_relationships': urls,
+            'extra_directories': []
+        } if input_f is None else input_f
+
 tools = {
-    # image: Dockerhub image with version tag
-    # description: Displayed in UI
-    # default_parameters: In demo, user can edit JSON.
-    #   (In Refinery, there is a UI.)
-    # default_files: Should match values in demo-data.csv.
-    #   (Doesn't need to be every possible valid input from that file.)
-    # input: Lambda which returns a dict which becomes the INPUT_JSON.
-    # container_port: If the tool uses a port other than 80.
-    # memory_use: Expected memory use in MB.
-    'debugger': {
-        'image': 'scottx611x/refinery-developer-vis-tool:v0.0.7',
-        'description': 'Echo the user input',
-        'default_parameters': [],
-        'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {'file_relationships': urls},
-        'memory_use': 15
-    },
-    'lineup': {
-        'image': 'mccalluc/lineup_refinery:v0.0.8',
-        'description': 'Aggregate and sort heterogeneous data',
-        'default_parameters': [],
-        'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {'file_relationships': urls},
-        'memory_use': 11
-    },
-    'intervene': {
-        'image': 'mccalluc/intervene:v0.0.5',
-        'description': 'Set intersection Shiny app',
-        'default_parameters': [],
-        'default_files': ['mESC.genes', 'Myotube.genes', 'pro-B.genes', 'Th-cell.genes'],
-        'input': lambda urls, prefix: {'file_relationships': urls},
-        'memory_use': 208
-    },
-    'shiny-demo': {
-        'image': 'mccalluc/shiny-heatmap-refinery:v0.0.2',
-        'description': 'Trivial Shiny app',
-        'default_parameters': [],
-        'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {'file_relationships': urls},
-        'container_port': 3838,
-        # Not sure why it needs to be 3838...
-        # but it's also good to exercise container_port.
-        # https://github.com/refinery-platform/shiny-heatmap-refinery/issues/2
-        'memory_use': 119
-    },
-    'igv-js': {
-        'image': 'gehlenborglab/docker_igv_js:v0.0.9',
-        'description': 'Our wrapper for IGV.js',
-        'default_parameters': [
+    'debugger': Tool(
+        'scottx611x/refinery-developer-vis-tool:v0.0.7',
+        'Echo the user input',
+        memory_use=15
+    ),
+    'lineup': Tool(
+        'mccalluc/lineup_refinery:v0.0.8',
+        'Aggregate and sort heterogeneous data',
+        memory_use=11
+    ),
+    'intervene': Tool(
+        'mccalluc/intervene:v0.0.5',
+        'Set intersection Shiny app',
+        default_files=['mESC.genes', 'Myotube.genes', 'pro-B.genes', 'Th-cell.genes'],
+        memory_use=208
+    ),
+    'shiny-demo': Tool(
+        'mccalluc/shiny-heatmap-refinery:v0.0.2',
+        'Trivial Shiny app',
+        container_port=3838,
+        memory_use=119
+    ),
+    'igv-js': Tool(
+        'gehlenborglab/docker_igv_js:v0.0.9',
+        'Our wrapper for IGV.js',
+        default_parameters=[
             {'name': 'Genome Build',
              'value': 'hg19'}
         ],
-        'default_files': ['NC_009084.gff'],
-        'input': lambda urls, prefix: {
+        default_files=['NC_009084.gff'],
+        input_f=lambda urls, prefix: {
             'node_info': {
                 'fake-uuid-{}'.format(i): {
                     'file_url': url,
@@ -63,43 +73,39 @@ tools = {
                 for (i, url) in enumerate(urls)
             },
         },
-        'memory_use': 15
-    },
-    'higlass': {
-        'image': 'scottx611x/refinery-higlass-docker:v0.3.2',
-        'description': '1-D and 2-D genomic data browser',
-        'default_parameters': [],
-        'default_files': ['gene_annotations.short.db', 'cnv_short.hibed'],
-        'input': lambda urls, prefix: {
+        memory_use=15
+    ),
+    'higlass': Tool(
+        'scottx611x/refinery-higlass-docker:v0.3.2',
+        '1-D and 2-D genomic data browser',
+        default_files=['gene_annotations.short.db', 'cnv_short.hibed'],
+        input_f=lambda urls, prefix: {
             'node_info': {
                 'fake-uuid-{}'.format(i): {'file_url': url}
                 for (i, url) in enumerate(urls)
             },
             'extra_directories': ['/refinery-data/']
         },
-        'memory_use': 100  # Highly variable
-    },
-    'rna-seq': {
-        'image': 'mccalluc/heatmap_scatter_dash:v0.1.8',
-        'description': 'Linked visualization for gene expression',
-        'default_parameters': [],
-        'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {
+        memory_use=100  # Highly variable
+    ),
+    'rna-seq': Tool(
+        'mccalluc/heatmap_scatter_dash:v0.1.8',
+        'Linked visualization for gene expression',
+        input_f=lambda urls, prefix: {
             'file_relationships': urls,
             'api_prefix': prefix,
             'extra_directories': ['/refinery-data/']
         },
-        'memory_use':  'TODO'
-    },
-    'multiqc': {
-        'image': 'mccalluc/qualimap_multiqc_refinery:v0.0.7',
-        'description': 'Wrapper for MultiQC',
-        'default_parameters': [],
-        'default_files': ['raw_data_qualimapReport.zip'],
-        'input': lambda urls, prefix: {
+        memory_use=20  # TODO: Confirm
+    ),
+    'multiqc': Tool(
+        'mccalluc/qualimap_multiqc_refinery:v0.0.7',
+        'Wrapper for MultiQC',
+        default_files=['raw_data_qualimapReport.zip'],
+        input_f=lambda urls, prefix: {
             'file_relationships': urls,
             'extra_directories': ['/data/']
         },
-        'memory_use': 20
-    }
+        memory_use=20
+    )
 }

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -1,28 +1,36 @@
-# The CSV also specifies which tool goes with each file... but I could imagine
-# listing multiple incompatible input sets there. The default_files here can
-# just be a simple, coherent example to start from.
-
 tools = {
+    # image: Dockerhub image with version tag
+    # description: Displayed in UI
+    # default_parameters: In demo, user can edit JSON.
+    #   (In Refinery, there is a UI.)
+    # default_files: Should match values in demo-data.csv.
+    #   (Doesn't need to be every possible valid input from that file.)
+    # input: Lambda which returns a dict which becomes the INPUT_JSON.
+    # container_port: If the tool uses a port other than 80.
+    # memory_use: Expected memory use in MB.
     'debugger': {
         'image': 'scottx611x/refinery-developer-vis-tool:v0.0.7',
         'description': 'Echo the user input',
         'default_parameters': [],
         'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {'file_relationships': urls}
+        'input': lambda urls, prefix: {'file_relationships': urls},
+        'memory_use': 15
     },
     'lineup': {
         'image': 'mccalluc/lineup_refinery:v0.0.8',
         'description': 'Aggregate and sort heterogeneous data',
         'default_parameters': [],
         'default_files': ['3x3.csv'],
-        'input': lambda urls, prefix: {'file_relationships': urls}
+        'input': lambda urls, prefix: {'file_relationships': urls},
+        'memory_use': 11
     },
     'intervene': {
         'image': 'mccalluc/intervene:v0.0.5',
         'description': 'Set intersection Shiny app',
         'default_parameters': [],
         'default_files': ['mESC.genes', 'Myotube.genes', 'pro-B.genes', 'Th-cell.genes'],
-        'input': lambda urls, prefix: {'file_relationships': urls}
+        'input': lambda urls, prefix: {'file_relationships': urls},
+        'memory_use': 208
     },
     'shiny-demo': {
         'image': 'mccalluc/shiny-heatmap-refinery:v0.0.2',
@@ -30,10 +38,11 @@ tools = {
         'default_parameters': [],
         'default_files': ['3x3.csv'],
         'input': lambda urls, prefix: {'file_relationships': urls},
-        'container_port': 3838
+        'container_port': 3838,
         # Not sure why it needs to be 3838...
         # but it's also good to exercise container_port.
         # https://github.com/refinery-platform/shiny-heatmap-refinery/issues/2
+        'memory_use': 119
     },
     'igv-js': {
         'image': 'gehlenborglab/docker_igv_js:v0.0.9',
@@ -53,7 +62,8 @@ tools = {
                 }
                 for (i, url) in enumerate(urls)
             },
-        }
+        },
+        'memory_use': 15
     },
     'higlass': {
         'image': 'scottx611x/refinery-higlass-docker:v0.3.2',
@@ -66,7 +76,8 @@ tools = {
                 for (i, url) in enumerate(urls)
             },
             'extra_directories': ['/refinery-data/']
-        }
+        },
+        'memory_use': 100  # Highly variable
     },
     'rna-seq': {
         'image': 'mccalluc/heatmap_scatter_dash:v0.1.8',
@@ -77,7 +88,8 @@ tools = {
             'file_relationships': urls,
             'api_prefix': prefix,
             'extra_directories': ['/refinery-data/']
-        }
+        },
+        'memory_use':  'TODO'
     },
     'multiqc': {
         'image': 'mccalluc/qualimap_multiqc_refinery:v0.0.7',
@@ -87,6 +99,7 @@ tools = {
         'input': lambda urls, prefix: {
             'file_relationships': urls,
             'extra_directories': ['/data/']
-        }
+        },
+        'memory_use': 20
     }
 }

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -14,6 +14,7 @@ class Tool():
     memory_use: Expected memory use in MB.
     '''
     # In 3.7, default values are supported for namedtuples. Until then:
+
     def __init__(self, image, description, memory_use,
                  default_parameters=None,
                  default_files=None, input_f=None, container_port=None):
@@ -23,13 +24,14 @@ class Tool():
         self.default_parameters = [] \
             if default_parameters is None else default_parameters
         self.default_files = ['3x3.csv'] \
-            if default_files is None  else default_files
+            if default_files is None else default_files
         self.container_port = 80 \
             if container_port is None else container_port
         self.input_f = lambda urls, prefix: {
             'file_relationships': urls,
             'extra_directories': []
         } if input_f is None else input_f
+
 
 tools = {
     'debugger': Tool(
@@ -45,7 +47,8 @@ tools = {
     'intervene': Tool(
         'mccalluc/intervene:v0.0.5',
         'Set intersection Shiny app',
-        default_files=['mESC.genes', 'Myotube.genes', 'pro-B.genes', 'Th-cell.genes'],
+        default_files=['mESC.genes', 'Myotube.genes',
+                       'pro-B.genes', 'Th-cell.genes'],
         memory_use=208
     ),
     'shiny-demo': Tool(

--- a/demo_path_routing_auth/tools.py
+++ b/demo_path_routing_auth/tools.py
@@ -16,8 +16,8 @@ class Tool():
     # In 3.7, default values are supported for namedtuples. Until then:
 
     def __init__(self, image, description, memory_use,
-                 default_parameters=None,
-                 default_files=None, input_f=None, container_port=None):
+                 default_parameters=None, default_files=None,
+                 container_port=None, extra_directories=None, input_f=None):
         self.image = image
         self.description = description
         self.memory_use = memory_use
@@ -27,10 +27,12 @@ class Tool():
             if default_files is None else default_files
         self.container_port = 80 \
             if container_port is None else container_port
-        self.input_f = lambda urls, prefix: {
+        self.extra_directories = [] \
+            if extra_directories is None else extra_directories
+        self.input_f = (lambda urls, prefix: {
             'file_relationships': urls,
             'extra_directories': []
-        } if input_f is None else input_f
+        }) if input_f is None else input_f
 
 
 tools = {
@@ -55,7 +57,7 @@ tools = {
         'mccalluc/shiny-heatmap-refinery:v0.0.2',
         'Trivial Shiny app',
         container_port=3838,
-        memory_use=119
+        memory_use=120
     ),
     'igv-js': Tool(
         'gehlenborglab/docker_igv_js:v0.0.9',

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -61,11 +61,11 @@ def index(request):
         'launch_form': launch_form,
         'upload_form': UploadForm(),
         'default_parameters_json': json.dumps({
-            k: v['default_parameters']
+            k: v.default_parameters
             for k, v in tools.items()
         }),
         'default_urls_json': json.dumps({
-            k: [name_to_url[f] for f in v['default_files']]
+            k: [name_to_url[f] for f in v.default_files]
             for k, v in tools.items()
         })
     }
@@ -103,7 +103,7 @@ def launch(request):
 
     container_name = post['container_name']
     container_path = '/docker/{}/'.format(container_name)
-    input_data = tool_spec['input'](input_urls, container_path)
+    input_data = tool_spec.input_f(input_urls, container_path)
     input_data['parameters'] = json.loads(post['parameters_json'])
 
     if post.get('show_input'):
@@ -111,10 +111,10 @@ def launch(request):
 
     container_spec = DockerContainerSpec(
         container_name=container_name,
-        image_name=tool_spec['image'],
+        image_name=tool_spec.image,
         input=input_data,
-        extra_directories=tool_spec.get('extra_directories') or [],
-        container_port=tool_spec.get('container_port') or 80,
+        extra_directories=input_data['extra_directories'],
+        container_port=tool_spec.container_port,
     )
     client.run(container_spec)
     return HttpResponseRedirect(container_path)

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -115,6 +115,7 @@ def launch(request):
         input=input_data,
         extra_directories=input_data.get('extra_directories'),
         container_port=tool_spec.container_port,
+        memory_use=tool_spec.memory_use
     )
     client.run(container_spec)
     return HttpResponseRedirect(container_path)

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -26,7 +26,12 @@ else:
 
 
 client = DockerClientRunWrapper(
-    DockerClientSpec(None, do_input_json_envvar=True))
+    DockerClientSpec(None, do_input_json_envvar=True),
+    memory_limit=1024*1024*20  # TODO: Hard-coded 20M limit for now
+    # We could also get the limit by starting a container and then:
+    #   sdk.list()[0].stats(stream=False)['memory_stats']['limit']
+    # but this can be slow: I don't want to do it on every launch.
+)
 UPLOAD_DIR = os.path.join(os.path.dirname(__file__), 'upload')
 
 with open(os.path.join(UPLOAD_DIR, 'demo-data.csv')) as csv_file:

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -113,7 +113,7 @@ def launch(request):
         container_name=container_name,
         image_name=tool_spec.image,
         input=input_data,
-        extra_directories=tool_spec.extra_directories,
+        extra_directories=input_data.get('extra_directories'),
         container_port=tool_spec.container_port,
     )
     client.run(container_spec)

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -113,7 +113,7 @@ def launch(request):
         container_name=container_name,
         image_name=tool_spec.image,
         input=input_data,
-        extra_directories=input_data['extra_directories'],
+        extra_directories=tool_spec.extra_directories,
         container_port=tool_spec.container_port,
     )
     client.run(container_spec)

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -27,7 +27,7 @@ else:
 
 client = DockerClientRunWrapper(
     DockerClientSpec(None, do_input_json_envvar=True),
-    memory_limit=1024*1024*20  # TODO: Hard-coded 20M limit for now
+    mem_limit_mb=20  # TODO: Hard-coded 20M limit for now
     # We could also get the limit by starting a container and then:
     #   sdk.list()[0].stats(stream=False)['memory_stats']['limit']
     # but this can be slow: I don't want to do it on every launch.
@@ -120,7 +120,7 @@ def launch(request):
         input=input_data,
         extra_directories=input_data.get('extra_directories'),
         container_port=tool_spec.container_port,
-        memory_use=tool_spec.memory_use
+        mem_reservation_mb=tool_spec.mem_reservation_mb
     )
     client.run(container_spec)
     return HttpResponseRedirect(container_path)

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -21,7 +21,8 @@ class DockerContainerSpec():
                  extra_directories=[],
                  labels={},
                  container_port=80,
-                 cpus=0.5):
+                 cpus=0.5,
+                 memory_use=None):
         self.image_name = image_name
         self.container_name = container_name
         self.container_input_path = container_input_path
@@ -30,6 +31,7 @@ class DockerContainerSpec():
         self.labels = labels
         self.container_port = container_port
         self.cpus = cpus
+        self.memory_use = memory_use
 
     def __repr__(self):
         kwargs = ', '.join(
@@ -115,8 +117,9 @@ class DockerClientWrapper(object):
                 ignore_errors=True
             )
 
-    def _memory_in_use(self, tool_defs):
+    def _memory_in_use(self):
         containers = self.list()
+        # import pdb; pdb.set_trace()
 
 
 
@@ -202,6 +205,9 @@ class DockerClientRunWrapper(DockerClientWrapper):
         Run a given ContainerSpec. Returns the url for the container,
         in contrast to the underlying method, which returns the logs.
         """
+
+        self._memory_in_use()  # TODO: Figure out how much memory is needed
+
         image_name = container_spec.image_name
         if (':' not in image_name):
             image_name += ':latest'
@@ -238,7 +244,8 @@ class DockerClientRunWrapper(DockerClientWrapper):
         labels = container_spec.labels
         labels.update({
             self.root_label: 'true',
-            self.root_label + '.port': str(container_spec.container_port)
+            self.root_label + '.port': str(container_spec.container_port),
+            self.root_label + '.memory_use': str(container_spec.memory_use)
         })
 
         environment = {}

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -118,7 +118,7 @@ class DockerClientWrapper(object):
                 ignore_errors=True
             )
 
-    def _memory_in_use(self):
+    def _total_memory_use(self):
         containers = self.list()
         return sum(
             [int(container.labels.get(_DEFAULT_LABEL + _MEMORY_USE))
@@ -208,7 +208,10 @@ class DockerClientRunWrapper(DockerClientWrapper):
         in contrast to the underlying method, which returns the logs.
         """
 
-        self._memory_in_use()  # TODO: Figure out how much memory is needed
+        memory_in_use = self._total_memory_use()
+        memory_requested = container_spec.memory_use
+        #memory_available =
+        #import pdb; pdb.set_trace()
 
         image_name = container_spec.image_name
         if (':' not in image_name):
@@ -265,7 +268,8 @@ class DockerClientRunWrapper(DockerClientWrapper):
             labels=labels,
             volumes=volumes,
             nano_cpus=int(container_spec.cpus * 1e9),
-            environment=environment
+            environment=environment,
+            mem_reservation='{}M'.format(memory_requested),
         )
         return self.lookup_container_url(container_spec.container_name)
 

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -69,6 +69,7 @@ class DockerClientSpec():
 
 _DEFAULT_MANAGER = docker_engine.DockerEngineManager
 _DEFAULT_LABEL = 'io.github.refinery-project.django_docker_engine'
+_MEMORY_USE = '.memory_use'
 
 
 class DockerClientWrapper(object):
@@ -119,7 +120,10 @@ class DockerClientWrapper(object):
 
     def _memory_in_use(self):
         containers = self.list()
-        # import pdb; pdb.set_trace()
+        return sum(
+            [int(container.labels.get(_DEFAULT_LABEL + _MEMORY_USE))
+             for container in containers]
+        )
 
 
 
@@ -245,7 +249,7 @@ class DockerClientRunWrapper(DockerClientWrapper):
         labels.update({
             self.root_label: 'true',
             self.root_label + '.port': str(container_spec.container_port),
-            self.root_label + '.memory_use': str(container_spec.memory_use)
+            self.root_label + _MEMORY_USE: str(container_spec.memory_use)
         })
 
         environment = {}

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -125,8 +125,6 @@ class DockerClientWrapper(object):
              for container in containers]
         )
 
-
-
     def _purge(self, label=None, seconds=None):
         for container in self.list({'label': label} if label else {}):
             # TODO: Confirm that the container belongs to me

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -211,7 +211,9 @@ class DockerClientRunWrapper(DockerClientWrapper):
         """
 
         total_mem_reservation_mb = self._total_mem_reservation_mb()
-        new_mem_reservation_mb = container_spec.mem_reservation_mb
+        new_mem_reservation_mb = container_spec.mem_reservation_mb or 0
+        # If None (ie, unspecified), treat as 0.
+
         if (total_mem_reservation_mb + new_mem_reservation_mb) > self._mem_limit_mb:
             # TODO: Kill LRU
             logger.warn('{}MB requested + {}MB in use > {}MB limit'.format(

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -212,7 +212,6 @@ class DockerClientRunWrapper(DockerClientWrapper):
 
         total_mem_reservation_mb = self._total_mem_reservation_mb()
         new_mem_reservation_mb = container_spec.mem_reservation_mb
-        import pdb;pdb.set_trace()
         if (total_mem_reservation_mb + new_mem_reservation_mb) > self._mem_limit_mb:
             # TODO: Kill LRU
             logger.warn('{}MB requested + {}MB in use > {}MB limit'.format(

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -115,6 +115,11 @@ class DockerClientWrapper(object):
                 ignore_errors=True
             )
 
+    def _memory_in_use(self, tool_defs):
+        containers = self.list()
+
+
+
     def _purge(self, label=None, seconds=None):
         for container in self.list({'label': label} if label else {}):
             # TODO: Confirm that the container belongs to me

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -190,7 +190,6 @@ class LiveDockerTestsClean(LiveDockerTests):
             'container_input_path': '/usr/share/nginx/html/index.html'
         }).url
         self.assert_loads_eventually(url, '{"foo": "bar"}')
-        self.client_wrapper._memory_in_use()  # TODO
 
     def assert_cpu_quota(self, expected, given={}):
 

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -190,6 +190,7 @@ class LiveDockerTestsClean(LiveDockerTests):
             'container_input_path': '/usr/share/nginx/html/index.html'
         }).url
         self.assert_loads_eventually(url, '{"foo": "bar"}')
+        self.client_wrapper._memory_in_use()  # TODO
 
     def assert_cpu_quota(self, expected, given={}):
 


### PR DESCRIPTION
- Tool defs include an estimate of memory needed
- This is stored as a label when the container is started
- When each successive container is started, we sum these labels of the running containers and compare it to the total memory available.

Right now, it just logs a warning if we're over the limit: the next step would be to kill (pause?) containers as necessary.

It could be possible to get the actual memory in use by a container, but:
- the API call takes time, and I wouldn't want to block on it,
- and it might be lower at one moment, and higher at another: For the others, memory use seems pretty stable, but HiGlass goes up and down.

Also:
- Store tool defs for demos as objects with sensible defaults, rather than dicts. There was a lot of repetition, and this is more readable, and if someone mistyped a key, we would catch it.
- Setting `mem_reservation` when containers start up: As I understand it, this is a soft limit that docker only enforces if there is resource contention. Seems like a good idea, but not fixing any definite bug either.

(This is a big step in a new direction, so I'll wait till you both have a chance to comment.)