### PR TITLE
Mccalluc/lru plus history

### DIFF
--- a/demo_path_routing_auth/index.html
+++ b/demo_path_routing_auth/index.html
@@ -64,13 +64,6 @@
                      target="_blank">history</a></td>
             </tr>
           {% endfor %}
-          <tr>
-            <td>
-              <form action="/kill_lru/" method="post">
-                {% csrf_token %}
-                <input type="submit" value="Kill LRU"></form></td>
-            <td></td>
-          </tr>
         </table>
       {% else %}
         There are no running containers.

--- a/demo_path_routing_auth/urls.py
+++ b/demo_path_routing_auth/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     url(r'^kill/(.*)$', views.kill),
     url(r'^logs/(.*)$', views.logs),
     url(r'^history/(.*)$', views.history),
-    url(r'^kill_lru/', views.kill_lru),
     url(r'^upload/(.*)$', views.upload),
     url(r'^docker/', include(__package__ + '.proxy_url_patterns'))
 ]

--- a/demo_path_routing_auth/views.py
+++ b/demo_path_routing_auth/views.py
@@ -27,7 +27,7 @@ else:
 
 client = DockerClientRunWrapper(
     DockerClientSpec(None, do_input_json_envvar=True),
-    mem_limit_mb=20  # TODO: Hard-coded 20M limit for now
+    mem_limit_mb=35  # TODO: Hard-coded limit for now
     # We could also get the limit by starting a container and then:
     #   sdk.list()[0].stats(stream=False)['memory_stats']['limit']
     # but this can be slow: I don't want to do it on every launch.
@@ -130,12 +130,6 @@ def launch(request):
 def kill(request, name):
     container = client.list(filters={'name': name})[0]
     client.kill(container)
-    return HttpResponseRedirect('/')
-
-
-@require_POST
-def kill_lru(request):
-    client.kill_lru()
     return HttpResponseRedirect('/')
 
 

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -147,8 +147,8 @@ class DockerClientWrapper(object):
             self.kill(next_container)
             logger.warn(
                 'Killed {} to free up {}MB: {}MB freed so far. '
-                    'Need to free {}.'.format(
-                next_container.name, mem_reservation_mb, memory_freed,
+                'Need to free {}.'.format(
+                    next_container.name, mem_reservation_mb, memory_freed,
                     need_to_free))
 
     def _mem_reservation_mb(self, container):
@@ -260,7 +260,7 @@ class DockerClientRunWrapper(DockerClientWrapper):
                     total_mem_reservation_mb,
                     self._mem_limit_mb,
                     need_to_free
-            ))
+                ))
             self._kill_lru(need_to_free)
 
         image_name = container_spec.image_name

--- a/django_docker_engine/docker_utils.py
+++ b/django_docker_engine/docker_utils.py
@@ -76,8 +76,10 @@ _MEM_RESERVATION_MB = '.mem_reservation_mb'
 class DockerClientWrapper(object):
 
     def __init__(self,
+                 historian=None,
                  manager_class=_DEFAULT_MANAGER,
                  root_label=_DEFAULT_LABEL):
+        self._historian = FileHistorian() if historian is None else historian
         self._containers_manager = manager_class(None, root_label)
         # Some methods of the manager will fail without a data_dir,
         # but they shouldn't be called from the read-only client in any event.
@@ -135,7 +137,7 @@ class DockerClientWrapper(object):
         '''
         container_ids = [container.id for container in self.list()]
         # TODO: Historian class should be parameterized.
-        lru_sorted = FileHistorian().sort_lru(container_ids)
+        lru_sorted = self._historian.sort_lru(container_ids)
         memory_freed = 0
         while memory_freed < need_to_free:
             next_id = lru_sorted.pop(0)

--- a/django_docker_engine/historian.py
+++ b/django_docker_engine/historian.py
@@ -56,12 +56,14 @@ class FileHistorian():
     def _last_timestamp(self, container_id):
         return os.path.getmtime(self._path(container_id))
 
-    def lru(self, container_id_set):
+    def sort_lru(self, container_id_set):
         '''
-        Of the given ids, which has the least-recent timestamp?
+        Returns the container IDs sorted with the least-recently-used first.
         '''
         id_timestamp_pairs = [
             (id, self._last_timestamp(id)) for id in container_id_set
         ]
-        oldest_pair = min(id_timestamp_pairs, key=lambda pair: pair[1])
-        return oldest_pair[0]
+        return [
+            pair[0] for pair in
+            sorted(id_timestamp_pairs, key=lambda pair: pair[1])
+        ]

--- a/tests/test_historian.py
+++ b/tests/test_historian.py
@@ -39,11 +39,11 @@ class FileHistorianTests(unittest.TestCase):
             historian._last_timestamp(id_1)
         )
 
-        lru = historian.lru({id_1, id_2, id_3, id_4})
-        self.assertEqual(lru, id_1)
+        lru = historian.sort_lru({id_1, id_2, id_3, id_4})
+        self.assertEqual(lru[0], id_1)
 
         sleep(1)
         historian.record(id_1, 'no longer the least recent!')
 
-        lru = historian.lru({id_1, id_2, id_3, id_4})
-        self.assertNotEqual(lru, id_1)
+        lru = historian.sort_lru({id_1, id_2, id_3, id_4})
+        self.assertNotEqual(lru[0], id_1)


### PR DESCRIPTION
Get rid of the manual `kill_lru` option in the demo which was just introduced to demonstrate the functionality... instead it's incorporated as part of the pre-flight check for run. 

Refinery will need to:
- Specify the total memory available
- optionally, provide an object which satisfies the historian interface, if you're squeamish about relying on file modification time.